### PR TITLE
Remove explicit dependency on Python 3.7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.3.0
+
+  - Remove explicit dependency on Python 3.7.
+
 ## v0.2.0
 
   - Allow customization of virtualenv and requirement file locations (#1).

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Create Python virtualenv
       run: |
         mkdir -p ${{ inputs.virtualenv-location }}
-        python3.7 -m venv ${{ inputs.virtualenv-location }};
+        python3 -m venv ${{ inputs.virtualenv-location }};
       shell: bash
     - name: Install requirements
       run: ${{ inputs.virtualenv-location }}/bin/pip install -r ${{ inputs.requirements-file }}


### PR DESCRIPTION
Use "python3" instead of "python3.7".